### PR TITLE
Update Sort v0 API endpoints to use Sort v1 API endpoints

### DIFF
--- a/src/pages/api/votes.ts
+++ b/src/pages/api/votes.ts
@@ -11,36 +11,45 @@ export default async function handler(
   const address = _address!.toString()
 
   const sortQuery = `
-    select
-      "from",
-      t.gas.transaction_fee.eth as gas
-    from
-      ${
-        sortWhitelistedContract.includes(address)
-          ? 'user14.transaction'
-          : 'ethereum.transaction'
-      } t
-    where
-        "to" = '${address}'
-        and status = 1
-        and t.function.name like '${type}'
-        and block_number > ${start_block}
-        and block_number < ${end_block}
-    order by
-      timestamp desc
-    LIMIT 10000
+  select
+    t.from_address as "from",
+    CAST((t.gas_limit * t.gas_price) / 1e18 as FLOAT) as gas
+  from
+    ethereum.transaction t,
+    ethereum.block b
+  where
+    t.block_id = b.id
+    and t.to_address = '${address}'
+    and t.function like '${type}'
+    and b.block_number > ${start_block}
+    and b.block_number < ${end_block}
+  order by
+    b.timestamp desc
+  LIMIT
+    100
   `
 
-  const data: SortResponse = await got('https://api.sort.xyz/v0/sql', {
-    method: 'POST',
-    json: {
-      query: sortQuery,
-      api_key: process.env.SORT_API_KEY,
-    },
-  }).json()
+  let rows = [] as any;
+  let meta = {} as any;
 
-  const rows = data.query_response.results
-  const meta = data.query_response.stats
+  // Loop though 10 pages of 100 records each
+  for (let i=0; i<10; i++) {
+    const data: SortResponse = await got
+    .post('https://api.sort.xyz/v1/queries/run', {
+      headers: {
+        'x-api-key': process.env.SORT_API_KEY,
+        'Accept': 'application/json',
+        'Content-Type': 'application/json'
+      },
+      json: { 
+        query : sortQuery + ` OFFSET ${i*100}`,
+      },
+    })
+    .json()
+
+    rows = rows.concat(data.data.records);
+    meta = data.data
+  }
 
   res.status(200).json({ rows, meta })
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -18,20 +18,13 @@ export type Response = {
 }
 
 export type SortResponse = {
-  id: string
-  success: number
-  query_response: {
-    collections: string[]
-    aliases: string[]
-    column_fields: Object[]
-
-    results: Response[]
-    query_id: string
-    stats: {
-      elapsed_time_ms: number
-      throttled_time_micros: number
-    }
-    status: string
+  code: number
+  data: {
+    durationMs: number
+    id: string
+    query: string
+    records: Response[]
+    recordCount: number
   }
 }
 


### PR DESCRIPTION
Update Sort v0 API endpoints to use Sort v1 API endpoints

Uses the past 1000 results instead of the past 10000 results, as a speed improvement.